### PR TITLE
perf(vltl): reduce interactive input latency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,14 @@ jobs:
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Run unit tests
         run: cargo test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,6 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          export PATH=$PATH:$(pwd)/target/release
+          export PATH=$(pwd)/target/release:$PATH
           chmod +x e2e_test.fish
           fish e2e_test.fish

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ cargo install vltl
    - The Korean trigger `ㅣ` is auto-registered as an abbr for next time
    - On macOS, the IME switches to English
 
+   Shift-derived uppercase letters are preserved by `vltl convert`. On macOS, executable command candidates are normalized to lowercase when the same lowercase file command exists, matching the default case-insensitive filesystem behavior.
+
    vltl binds `space`, `enter`, and `;` so that any Korean token is converted to its QWERTY equivalent before fish's native abbreviation expansion runs.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cargo install vltl
 
    vltl binds `space`, `enter`, and `;` so that any Korean token is converted to its QWERTY equivalent before fish's native abbreviation expansion runs.
 
-   ASCII-only tokens are filtered by fish without starting `vltl`. For Korean input, detection, command-position parsing, and conversion run in one `vltl resolve` process. The operating system is detected once when the init script is sourced.
+   ASCII-only tokens and existing Korean abbreviations are filtered by fish without starting `vltl`. For new Korean input, detection, command-position parsing, and conversion run in one `vltl resolve` process. The operating system is detected once when the init script is sourced.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cargo install vltl
 
    vltl binds `space`, `enter`, and `;` so that any Korean token is converted to its QWERTY equivalent before fish's native abbreviation expansion runs.
 
+   ASCII-only tokens are filtered by fish without starting `vltl`. For Korean input, detection, command-position parsing, and conversion run in one `vltl resolve` process. The operating system is detected once when the init script is sourced.
+
 ## Development
 
 ### Running Tests
@@ -89,6 +91,7 @@ The e2e tests verify:
 - Function definitions after sourcing init (`__vltl_convert_and_expand`, `__vltl_auto_register_abbr`, etc.)
 - Korean-to-English conversion via `vltl convert`
 - Korean detection via `vltl has-korean`
+- Combined Korean detection, command-position parsing, and conversion via `vltl resolve`
 - Automatic abbr registration for Korean triggers
 - Preservation of abbr options (`--position anywhere`, `--set-cursor`, etc.)
 - No duplicate abbr registration

--- a/e2e_test.fish
+++ b/e2e_test.fish
@@ -236,6 +236,12 @@ function test_resolve_command
     else
         print_test_result "resolve: init avoids legacy vltl subprocess chain" 1
     end
+
+    if string match -q '*abbr -q -- "$token"*' -- "$init_content"
+        print_test_result "resolve: existing Korean abbr bypasses vltl" 0
+    else
+        print_test_result "resolve: existing Korean abbr bypasses vltl" 1
+    end
 end
 
 function test_auto_register_abbr

--- a/e2e_test.fish
+++ b/e2e_test.fish
@@ -199,6 +199,45 @@ function test_has_korean_command
     end
 end
 
+function test_resolve_command
+    echo ""
+    echo "Testing combined resolve command..."
+
+    set -l result (vltl resolve -- "햣" "햣 status" 1)
+    if test $status -eq 0; and test "$result" = git
+        print_test_result "resolve: converts a Korean command" 0
+    else
+        print_test_result "resolve: converts a Korean command (got: $result)" 1
+    end
+
+    set result (vltl resolve -- "ㅎ" "echo ㅎ" 6)
+    if test $status -eq 1; and test -z "$result"
+        print_test_result "resolve: ignores a Korean argument" 0
+    else
+        print_test_result "resolve: ignores a Korean argument" 1
+    end
+
+    set result (vltl resolve -- git "git status" 3)
+    if test $status -eq 1; and test -z "$result"
+        print_test_result "resolve: ignores an ASCII command" 0
+    else
+        print_test_result "resolve: ignores an ASCII command" 1
+    end
+
+    set -l init_content (vltl init)
+    if string match -q '*$__vltl_bin resolve*' -- "$init_content"
+        print_test_result "resolve: init uses one combined vltl call" 0
+    else
+        print_test_result "resolve: init uses one combined vltl call" 1
+    end
+
+    if not string match -qr '\$__vltl_bin (has-korean|is-command-position|convert)' -- "$init_content"
+        print_test_result "resolve: init avoids legacy vltl subprocess chain" 0
+    else
+        print_test_result "resolve: init avoids legacy vltl subprocess chain" 1
+    end
+end
+
 function test_auto_register_abbr
     echo ""
     echo "Testing abbr auto-registration..."
@@ -544,6 +583,7 @@ echo "========================================"
 test_function_definitions
 test_convert_command
 test_has_korean_command
+test_resolve_command
 test_auto_register_abbr
 test_auto_register_preserves_options
 test_auto_register_no_duplicate

--- a/e2e_test.fish
+++ b/e2e_test.fish
@@ -33,6 +33,12 @@ function test_function_definitions
         print_test_result "function __vltl_convert_and_expand is defined" 1
     end
 
+    if type -q __vltl_resolve_command
+        print_test_result "function __vltl_resolve_command is defined" 0
+    else
+        print_test_result "function __vltl_resolve_command is defined" 1
+    end
+
     # Test: __vltl_auto_register_abbr is defined
     if type -q __vltl_auto_register_abbr
         print_test_result "function __vltl_auto_register_abbr is defined" 0
@@ -72,6 +78,39 @@ function test_function_definitions
         print_test_result "old __vltl_check helper is not defined" 0
     else
         print_test_result "old __vltl_check helper is not defined" 1
+    end
+end
+
+function test_macos_case_insensitive_command
+    echo ""
+    echo "Testing macOS case-insensitive executable resolution..."
+
+    vltl init | source
+
+    set -l converted (vltl convert "ㅎㅑㅆ")
+    if test "$converted" = giT
+        print_test_result "case handling: shifted Dubeolsik input remains giT" 0
+    else
+        print_test_result "case handling: shifted Dubeolsik input remains giT (got: $converted)" 1
+    end
+
+    function GiT
+    end
+    set -l function_candidate (__vltl_resolve_command GiT)
+    functions --erase GiT
+    if test "$function_candidate" = GiT
+        print_test_result "case handling: case-sensitive fish function is preserved" 0
+    else
+        print_test_result "case handling: case-sensitive fish function is preserved (got: $function_candidate)" 1
+    end
+
+    if __vltl_is_macos
+        set -l resolved (__vltl_resolve_command "$converted")
+        if test "$resolved" = git
+            print_test_result "case handling: macOS executable resolves to lowercase git" 0
+        else
+            print_test_result "case handling: macOS executable resolves to lowercase git (got: $resolved)" 1
+        end
     end
 end
 
@@ -320,11 +359,11 @@ function test_switch_to_english_command
             print_test_result "switch-to-english command exists on macOS" 1
         end
 
-        # Test 2: Command should execute without error (even if IME doesn't change)
-        if vltl switch-to-english 2>&1 | grep -qv "error: unrecognized subcommand"
-            print_test_result "switch-to-english command executes on macOS" 0
+        # Test 2: Command-specific help should be available without changing IME state
+        if vltl switch-to-english --help >/dev/null
+            print_test_result "switch-to-english command help is available on macOS" 0
         else
-            print_test_result "switch-to-english command executes on macOS" 1
+            print_test_result "switch-to-english command help is available on macOS" 1
         end
     else
         echo "Running on Linux - verifying switch-to-english is not available"
@@ -421,12 +460,12 @@ function test_no_abbr_for_nonexistent_command
     # Source the init script
     vltl init | source
 
-    # Verify the init script includes a type -q guard for command existence
+    # Verify the init script includes the command resolution guard
     set -l init_content (vltl init)
-    if echo "$init_content" | grep -q 'type -q'
-        print_test_result "guard: init script includes type -q check" 0
+    if echo "$init_content" | grep -q '__vltl_resolve_command'
+        print_test_result "guard: init script includes command resolution" 0
     else
-        print_test_result "guard: init script includes type -q check" 1
+        print_test_result "guard: init script includes command resolution" 1
     end
 
     # Verify that a non-existent command is not recognized by type -q or abbr -q
@@ -515,6 +554,7 @@ test_extract_programs_command
 test_is_command_position
 test_no_abbr_for_nonexistent_command
 test_integration_convert_flow
+test_macos_case_insensitive_command
 
 # Print summary
 echo ""

--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,7 @@
+set -g __vltl_platform (uname -s)
+
 function __vltl_is_macos
-    test (uname -s) = Darwin
+    test "$__vltl_platform" = Darwin
 end
 
 function __vltl_resolve_command
@@ -37,37 +39,34 @@ end
 function __vltl_convert_and_expand
     set -l token (commandline --current-token)
 
+    if test -z "$token"; or not string match -qr '[^\x00-\x7F]' -- "$token"
+        return
+    end
+
     # $VLTL_PATH가 설정되어 있으면 해당 경로의 vltl을 사용, 아니면 PATH의 vltl 사용
     set -l __vltl_bin vltl
     if set -q VLTL_PATH
         set __vltl_bin $VLTL_PATH
     end
 
-    if test -n "$token"; and $__vltl_bin has-korean -- "$token"
-        # 커서가 명령어 이름 위치에 있는지 AST로 확인
-        set -l cmdline (commandline)
-        set -l cursor_pos (commandline --cursor)
-        if not $__vltl_bin is-command-position -- "$cmdline" "$cursor_pos"
-            return
-        end
+    set -l cmdline (commandline)
+    set -l cursor_pos (commandline --cursor)
+    set -l converted ($__vltl_bin resolve -- "$token" "$cmdline" "$cursor_pos")
+    or return
 
-        set -l converted ($__vltl_bin convert -- "$token")
-        if test -n "$converted"; and test "$converted" != "$token"
-            set converted (__vltl_resolve_command "$converted")
-            or return
+    set converted (__vltl_resolve_command "$converted")
+    or return
 
-            commandline --current-token --replace -- "$converted"
+    commandline --current-token --replace -- "$converted"
 
-            # 변환된 토큰에 대응하는 abbr이 있으면 한글 트리거로 자동 등록
-            if abbr -q -- "$converted"
-                __vltl_auto_register_abbr "$token" "$converted"
-            end
+    # 변환된 토큰에 대응하는 abbr이 있으면 한글 트리거로 자동 등록
+    if abbr -q -- "$converted"
+        __vltl_auto_register_abbr "$token" "$converted"
+    end
 
-            # Switch IME to English (only available on macOS)
-            if __vltl_is_macos
-                $__vltl_bin switch-to-english 2>/dev/null
-            end
-        end
+    # Switch IME to English (only available on macOS)
+    if __vltl_is_macos
+        $__vltl_bin switch-to-english 2>/dev/null
     end
 end
 

--- a/init.fish
+++ b/init.fish
@@ -43,6 +43,10 @@ function __vltl_convert_and_expand
         return
     end
 
+    if abbr -q -- "$token"
+        return
+    end
+
     # $VLTL_PATH가 설정되어 있으면 해당 경로의 vltl을 사용, 아니면 PATH의 vltl 사용
     set -l __vltl_bin vltl
     if set -q VLTL_PATH

--- a/init.fish
+++ b/init.fish
@@ -1,3 +1,39 @@
+function __vltl_is_macos
+    test (uname -s) = Darwin
+end
+
+function __vltl_resolve_command
+    set -l candidate $argv[1]
+
+    if abbr -q -- "$candidate"
+        printf '%s\n' "$candidate"
+        return 0
+    end
+
+    set -l candidate_type (type -t -- "$candidate" 2>/dev/null)
+    if test -n "$candidate_type"; and test "$candidate_type" != file
+        printf '%s\n' "$candidate"
+        return 0
+    end
+
+    if __vltl_is_macos
+        set -l lowercase_candidate (string lower -- "$candidate")
+        if test "$lowercase_candidate" != "$candidate"
+            if test (type -t -- "$lowercase_candidate" 2>/dev/null) = file
+                printf '%s\n' "$lowercase_candidate"
+                return 0
+            end
+        end
+    end
+
+    if test "$candidate_type" = file
+        printf '%s\n' "$candidate"
+        return 0
+    end
+
+    return 1
+end
+
 function __vltl_convert_and_expand
     set -l token (commandline --current-token)
 
@@ -17,10 +53,8 @@ function __vltl_convert_and_expand
 
         set -l converted ($__vltl_bin convert -- "$token")
         if test -n "$converted"; and test "$converted" != "$token"
-            # 존재하지 않는 명령어에 대해서는 변환하지 않음
-            if not type -q "$converted"; and not abbr -q -- "$converted"
-                return
-            end
+            set converted (__vltl_resolve_command "$converted")
+            or return
 
             commandline --current-token --replace -- "$converted"
 
@@ -30,7 +64,9 @@ function __vltl_convert_and_expand
             end
 
             # Switch IME to English (only available on macOS)
-            $__vltl_bin switch-to-english 2>/dev/null
+            if __vltl_is_macos
+                $__vltl_bin switch-to-english 2>/dev/null
+            end
         end
     end
 end

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -194,22 +194,22 @@ mod tests {
         assert!(contains_korean("며"));
         assert!(contains_korean("내"));
         assert!(contains_korean("안녕하세요"));
-        
+
         // 한글 자모
         assert!(contains_korean("ㅍㅣ"));
         assert!(contains_korean("ㅔㅞㅡ"));
         assert!(contains_korean("ㅛㅁ구"));
-        
+
         // 영문
         assert!(!contains_korean("ls"));
         assert!(!contains_korean("npm"));
         assert!(!contains_korean("hello"));
         assert!(!contains_korean("nonexistent"));
-        
+
         // 혼합
         assert!(contains_korean("ls안녕"));
         assert!(contains_korean("helloㅎㅎ"));
-        
+
         // 기타
         assert!(!contains_korean(""));
         assert!(!contains_korean("123"));

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,186 +1,149 @@
-use std::collections::HashMap;
-use std::sync::LazyLock;
 use unicode_normalization::UnicodeNormalization;
 
-/// 한국어 키보드로 잘못 입력된 명령어를 영어로 변환하는 매핑
-static KOREAN_TO_ENGLISH_MAP: LazyLock<HashMap<char, &'static str>> = LazyLock::new(|| {
-    let mut map: HashMap<char, &'static str> = HashMap::new();
+const INITIAL_KEYS: [&str; 19] = [
+    "r", "R", "s", "e", "E", "f", "a", "q", "Q", "t", "T", "d", "w", "W", "c", "z", "x", "v", "g",
+];
 
-    // 자음
-    map.insert('ㅂ', "q");
-    map.insert('ㅈ', "w");
-    map.insert('ㄷ', "e");
-    map.insert('ㄱ', "r");
-    map.insert('ㅅ', "t");
-    map.insert('ㅛ', "y");
-    map.insert('ㅕ', "u");
-    map.insert('ㅑ', "i");
-    map.insert('ㅐ', "o");
-    map.insert('ㅔ', "p");
+const MEDIAL_KEYS: [&str; 21] = [
+    "k", "o", "i", "O", "j", "p", "u", "P", "h", "hk", "ho", "hl", "y", "n", "nj", "np", "nl", "b",
+    "m", "ml", "l",
+];
 
-    map.insert('ㅁ', "a");
-    map.insert('ㄴ', "s");
-    map.insert('ㅇ', "d");
-    map.insert('ㄹ', "f");
-    map.insert('ㅎ', "g");
-    map.insert('ㅗ', "h");
-    map.insert('ㅓ', "j");
-    map.insert('ㅏ', "k");
-    map.insert('ㅣ', "l");
+const FINAL_KEYS: [&str; 28] = [
+    "", "r", "R", "rt", "s", "sw", "sg", "e", "f", "fr", "fa", "fq", "ft", "fx", "fv", "fg", "a",
+    "q", "qt", "t", "T", "d", "w", "c", "z", "x", "v", "g",
+];
 
-    map.insert('ㅋ', "z");
-    map.insert('ㅌ', "x");
-    map.insert('ㅊ', "c");
-    map.insert('ㅍ', "v");
-    map.insert('ㅠ', "b");
-    map.insert('ㅜ', "n");
-    map.insert('ㅡ', "m");
-
-    // 쌍자음
-    map.insert('ㅃ', "Q");
-    map.insert('ㅉ', "W");
-    map.insert('ㄸ', "E");
-    map.insert('ㄲ', "R");
-    map.insert('ㅆ', "T");
-
-    // 복합모음: 두벌식 키 시퀀스에 맞춰 2글자 이상으로 매핑
-    map.insert('ㅒ', "O"); // ㅒ (yae) → 보통 Shift+o로 들어온 호환자모
-    map.insert('ㅖ', "P"); // ㅖ (ye)  → 보통 Shift+p
-    map.insert('ㅘ', "hk"); // ㅗ+ㅏ
-    map.insert('ㅙ', "ho"); // ㅗ+ㅐ
-    map.insert('ㅚ', "hl"); // ㅗ+ㅣ
-    map.insert('ㅝ', "nj"); // ㅜ+ㅓ
-    map.insert('ㅞ', "np"); // ㅜ+ㅔ
-    map.insert('ㅟ', "nl"); // ㅜ+ㅣ
-    map.insert('ㅢ', "ml"); // ㅡ+ㅣ
-
-    // 겹받침 (compound final consonants)
-    map.insert('ㄳ', "rt"); // ㄱ+ㅅ
-    map.insert('ㄵ', "sw"); // ㄴ+ㅈ
-    map.insert('ㄶ', "sg"); // ㄴ+ㅎ
-    map.insert('ㄺ', "fr"); // ㄹ+ㄱ
-    map.insert('ㄻ', "fa"); // ㄹ+ㅁ
-    map.insert('ㄼ', "fq"); // ㄹ+ㅂ
-    map.insert('ㄽ', "ft"); // ㄹ+ㅅ
-    map.insert('ㄾ', "fx"); // ㄹ+ㅌ
-    map.insert('ㄿ', "fv"); // ㄹ+ㅍ
-    map.insert('ㅀ', "fg"); // ㄹ+ㅎ
-    map.insert('ㅄ', "qt"); // ㅂ+ㅅ
-
-    map
-});
-
-/// 한글 완성형 문자를 자모로 분해
-fn decompose_hangul(ch: char) -> Vec<char> {
-    let code = ch as u32;
-
-    // 한글 음절 범위 (가-힣: U+AC00 - U+D7A3)
-    if (0xAC00..=0xD7A3).contains(&code) {
-        let base = code - 0xAC00;
-
-        // 초성, 중성, 종성 인덱스 계산
-        let chosung_idx = base / (21 * 28);
-        let jungsung_idx = (base % (21 * 28)) / 28;
-        let jongsung_idx = base % 28;
-
-        // 초성 테이블
-        let chosung = [
-            'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ',
-            'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ',
-        ];
-
-        // 중성 테이블
-        let jungsung = [
-            'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ',
-            'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ',
-        ];
-
-        // 종성 테이블 (첫 번째는 빈 종성)
-        let jongsung = [
-            "", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ", "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ",
-            "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ",
-        ];
-
-        let mut result = Vec::new();
-
-        if let Some(cho) = chosung.get(chosung_idx as usize) {
-            result.push(*cho);
-        }
-        if let Some(jung) = jungsung.get(jungsung_idx as usize) {
-            result.push(*jung);
-        }
-        if jongsung_idx > 0
-            && let Some(jong) = jongsung.get(jongsung_idx as usize)
-        {
-            for c in jong.chars() {
-                result.push(c);
-            }
-        }
-        result
-    } else {
-        // 완성형이 아니면 그대로 반환
-        vec![ch]
+fn compatibility_jamo_keys(character: char) -> Option<&'static str> {
+    match character {
+        'ㄱ' => Some("r"),
+        'ㄲ' => Some("R"),
+        'ㄳ' => Some("rt"),
+        'ㄴ' => Some("s"),
+        'ㄵ' => Some("sw"),
+        'ㄶ' => Some("sg"),
+        'ㄷ' => Some("e"),
+        'ㄸ' => Some("E"),
+        'ㄹ' => Some("f"),
+        'ㄺ' => Some("fr"),
+        'ㄻ' => Some("fa"),
+        'ㄼ' => Some("fq"),
+        'ㄽ' => Some("ft"),
+        'ㄾ' => Some("fx"),
+        'ㄿ' => Some("fv"),
+        'ㅀ' => Some("fg"),
+        'ㅁ' => Some("a"),
+        'ㅂ' => Some("q"),
+        'ㅃ' => Some("Q"),
+        'ㅄ' => Some("qt"),
+        'ㅅ' => Some("t"),
+        'ㅆ' => Some("T"),
+        'ㅇ' => Some("d"),
+        'ㅈ' => Some("w"),
+        'ㅉ' => Some("W"),
+        'ㅊ' => Some("c"),
+        'ㅋ' => Some("z"),
+        'ㅌ' => Some("x"),
+        'ㅍ' => Some("v"),
+        'ㅎ' => Some("g"),
+        'ㅏ' => Some("k"),
+        'ㅐ' => Some("o"),
+        'ㅑ' => Some("i"),
+        'ㅒ' => Some("O"),
+        'ㅓ' => Some("j"),
+        'ㅔ' => Some("p"),
+        'ㅕ' => Some("u"),
+        'ㅖ' => Some("P"),
+        'ㅗ' => Some("h"),
+        'ㅘ' => Some("hk"),
+        'ㅙ' => Some("ho"),
+        'ㅚ' => Some("hl"),
+        'ㅛ' => Some("y"),
+        'ㅜ' => Some("n"),
+        'ㅝ' => Some("nj"),
+        'ㅞ' => Some("np"),
+        'ㅟ' => Some("nl"),
+        'ㅠ' => Some("b"),
+        'ㅡ' => Some("m"),
+        'ㅢ' => Some("ml"),
+        'ㅣ' => Some("l"),
+        _ => None,
     }
 }
 
-/// 문자열에 한국어 문자가 포함되어 있는지 확인
-/// - 한글 완성형 음절 (가-힣: U+AC00 - U+D7A3)
-/// - 한글 자모 (ㄱ-ㅎ, ㅏ-ㅣ: U+3131 - U+318E)
+fn canonical_jamo_keys(character: char) -> Option<&'static str> {
+    let code = character as u32;
+
+    match code {
+        0x1100..=0x1112 => INITIAL_KEYS.get((code - 0x1100) as usize).copied(),
+        0x1161..=0x1175 => MEDIAL_KEYS.get((code - 0x1161) as usize).copied(),
+        0x11A8..=0x11C2 => FINAL_KEYS.get((code - 0x11A7) as usize).copied(),
+        _ => None,
+    }
+}
+
+fn append_syllable_keys(output: &mut String, character: char) -> bool {
+    let code = character as u32;
+    if !(0xAC00..=0xD7A3).contains(&code) {
+        return false;
+    }
+
+    let syllable_index = code - 0xAC00;
+    let initial_index = syllable_index / (21 * 28);
+    let medial_index = (syllable_index % (21 * 28)) / 28;
+    let final_index = syllable_index % 28;
+
+    output.push_str(INITIAL_KEYS[initial_index as usize]);
+    output.push_str(MEDIAL_KEYS[medial_index as usize]);
+    output.push_str(FINAL_KEYS[final_index as usize]);
+    true
+}
+
 pub fn contains_korean(input: &str) -> bool {
-    input.chars().any(|c| {
-        let code = c as u32;
-        // 한글 완성형 음절 (가-힣)
+    input.chars().any(|character| {
+        let code = character as u32;
         (0xAC00..=0xD7A3).contains(&code)
-            // 한글 자모 (ㄱ-ㅎ, ㅏ-ㅣ)
             || (0x3131..=0x318E).contains(&code)
+            || (0x1100..=0x11FF).contains(&code)
+            || (0xA960..=0xA97F).contains(&code)
+            || (0xD7B0..=0xD7FF).contains(&code)
     })
 }
 
-/// 한국어로 입력된 문자열을 영어로 변환
-/// - 먼저 NFC 정규화를 수행하여 가능한 경우 완성형으로 결합
-/// - 이후 음절은 자모로 분해, 단일 자모는 그대로 두고 매핑으로 변환
-pub fn convert_korean_to_english(korean_input: &str) -> String {
-    let map = &*KOREAN_TO_ENGLISH_MAP;
+/// 두벌식 한글 입력을 같은 키 위치의 영문 QWERTY 문자열로 변환합니다.
+pub fn convert_korean_to_english(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
 
-    // NFC 정규화로 NFD 입력을 최대한 완성형으로 결합
-    let normalized: String = korean_input.nfc().collect();
+    for character in input.nfc() {
+        if append_syllable_keys(&mut output, character) {
+            continue;
+        }
 
-    normalized
-        .chars()
-        .flat_map(decompose_hangul)
-        .flat_map(|jamo| {
-            // 매핑이 있으면 그 문자열을, 없으면 원문 글자를 사용
-            if let Some(out) = map.get(&jamo) {
-                out.chars().collect::<Vec<char>>()
-            } else {
-                vec![jamo]
-            }
-        })
-        .collect()
+        if let Some(keys) =
+            compatibility_jamo_keys(character).or_else(|| canonical_jamo_keys(character))
+        {
+            output.push_str(keys);
+        } else {
+            output.push(character);
+        }
+    }
+
+    output
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{contains_korean, convert_korean_to_english};
 
     #[test]
-    fn test_simple_conversion() {
+    fn converts_simple_syllables() {
         assert_eq!(convert_korean_to_english("피"), "vl");
         assert_eq!(convert_korean_to_english("며"), "au");
         assert_eq!(convert_korean_to_english("내"), "so");
     }
 
     #[test]
-    fn test_decompose_hangul() {
-        let result = decompose_hangul('며');
-        assert_eq!(result, vec!['ㅁ', 'ㅕ']);
-
-        let result = decompose_hangul('피');
-        assert_eq!(result, vec!['ㅍ', 'ㅣ']);
-    }
-
-    #[test]
-    fn test_non_completed() {
+    fn converts_incomplete_input() {
         assert_eq!(convert_korean_to_english("ㅍㅣ"), "vl");
         assert_eq!(convert_korean_to_english("ㅔㅞㅡ"), "pnpm");
         assert_eq!(convert_korean_to_english("ㅛㅁ구"), "yarn");
@@ -188,47 +151,37 @@ mod tests {
     }
 
     #[test]
-    fn test_contains_korean() {
-        // 한글 완성형
-        assert!(contains_korean("피"));
-        assert!(contains_korean("며"));
-        assert!(contains_korean("내"));
-        assert!(contains_korean("안녕하세요"));
-
-        // 한글 자모
-        assert!(contains_korean("ㅍㅣ"));
-        assert!(contains_korean("ㅔㅞㅡ"));
-        assert!(contains_korean("ㅛㅁ구"));
-
-        // 영문
-        assert!(!contains_korean("ls"));
-        assert!(!contains_korean("npm"));
-        assert!(!contains_korean("hello"));
-        assert!(!contains_korean("nonexistent"));
-
-        // 혼합
-        assert!(contains_korean("ls안녕"));
-        assert!(contains_korean("helloㅎㅎ"));
-
-        // 기타
-        assert!(!contains_korean(""));
-        assert!(!contains_korean("123"));
-        assert!(!contains_korean("!@#$"));
+    fn converts_compound_jamo() {
+        assert_eq!(convert_korean_to_english("까싸"), "RkTk");
+        assert_eq!(convert_korean_to_english("없"), "djqt");
+        assert_eq!(convert_korean_to_english("닭"), "ekfr");
+        assert_eq!(convert_korean_to_english("읽"), "dlfr");
+        assert_eq!(convert_korean_to_english("삶"), "tkfa");
+        assert_eq!(convert_korean_to_english("값"), "rkqt");
+        assert_eq!(convert_korean_to_english("넓"), "sjfq");
+        assert_eq!(convert_korean_to_english("앉"), "dksw");
+        assert_eq!(convert_korean_to_english("않"), "dksg");
+        assert_eq!(convert_korean_to_english("잃"), "dlfg");
+        assert_eq!(convert_korean_to_english("핥"), "gkfx");
+        assert_eq!(convert_korean_to_english("읊"), "dmfv");
+        assert_eq!(convert_korean_to_english("ㅘㄳ"), "hkrt");
     }
 
     #[test]
-    fn test_compound_jongsung() {
-        // 겹받침이 포함된 음절들의 변환 테스트
-        assert_eq!(convert_korean_to_english("없"), "djqt"); // ㅇ+ㅓ+ㅂㅅ
-        assert_eq!(convert_korean_to_english("닭"), "ekfr"); // ㄷ+ㅏ+ㄹㄱ
-        assert_eq!(convert_korean_to_english("읽"), "dlfr"); // ㅇ+ㅣ+ㄹㄱ
-        assert_eq!(convert_korean_to_english("삶"), "tkfa"); // ㅅ+ㅏ+ㄹㅁ
-        assert_eq!(convert_korean_to_english("값"), "rkqt"); // ㄱ+ㅏ+ㅂㅅ
-        assert_eq!(convert_korean_to_english("넓"), "sjfq"); // ㄴ+ㅓ+ㄹㅂ
-        assert_eq!(convert_korean_to_english("앉"), "dksw"); // ㅇ+ㅏ+ㄴㅈ
-        assert_eq!(convert_korean_to_english("않"), "dksg"); // ㅇ+ㅏ+ㄴㅎ
-        assert_eq!(convert_korean_to_english("잃"), "dlfg"); // ㅇ+ㅣ+ㄹㅎ
-        assert_eq!(convert_korean_to_english("핥"), "gkfx"); // ㅎ+ㅏ+ㄹㅌ
-        assert_eq!(convert_korean_to_english("읊"), "dmfv"); // ㅇ+ㅡ+ㄹㅍ
+    fn normalizes_canonical_jamo() {
+        assert_eq!(
+            convert_korean_to_english("\u{1100}\u{116A}\u{11AA}"),
+            "rhkrt"
+        );
+    }
+
+    #[test]
+    fn detects_korean_ranges() {
+        assert!(contains_korean("안녕하세요"));
+        assert!(contains_korean("ㅍㅣ"));
+        assert!(contains_korean("\u{1100}\u{1161}"));
+        assert!(!contains_korean("hello"));
+        assert!(!contains_korean("123!"));
+        assert!(!contains_korean(""));
     }
 }

--- a/src/fish_parser.rs
+++ b/src/fish_parser.rs
@@ -1,8 +1,7 @@
-/// Fish shell command line parser for extracting program names.
-///
-/// Uses [tree-sitter-fish](https://github.com/ram02z/tree-sitter-fish) to parse
-/// Fish command lines and extract the program name from each command.
-
+//! Fish shell command line parser for extracting program names.
+//!
+//! Uses [tree-sitter-fish](https://github.com/ram02z/tree-sitter-fish) to parse
+//! Fish command lines and extract the program name from each command.
 use tree_sitter::{Node, Parser};
 
 /// Extract program names from a Fish shell command line.
@@ -119,10 +118,10 @@ fn node_text_unquoted(node: &Node, source: &[u8]) -> String {
 /// Get the program name from a `command` node, skipping any leading variable assignments.
 fn get_program_name(command_node: &Node, source: &[u8]) -> Option<String> {
     // Check the `name` field (first token of the command)
-    if let Some(name_node) = command_node.child_by_field_name("name") {
-        if !is_assignment_word(&name_node, source) {
-            return Some(node_text_unquoted(&name_node, source));
-        }
+    if let Some(name_node) = command_node.child_by_field_name("name")
+        && !is_assignment_word(&name_node, source)
+    {
+        return Some(node_text_unquoted(&name_node, source));
     }
     // The `name` field was a variable assignment — look through `argument` fields
     let mut cursor = command_node.walk();
@@ -144,10 +143,10 @@ fn get_program_name(command_node: &Node, source: &[u8]) -> Option<String> {
 
 /// Get the byte range `(start, end)` of the program name from a `command` node.
 fn get_program_name_range(command_node: &Node, source: &[u8]) -> Option<(usize, usize)> {
-    if let Some(name_node) = command_node.child_by_field_name("name") {
-        if !is_assignment_word(&name_node, source) {
-            return Some((name_node.start_byte(), name_node.end_byte()));
-        }
+    if let Some(name_node) = command_node.child_by_field_name("name")
+        && !is_assignment_word(&name_node, source)
+    {
+        return Some((name_node.start_byte(), name_node.end_byte()));
     }
     let mut cursor = command_node.walk();
     if cursor.goto_first_child() {
@@ -254,7 +253,10 @@ mod tests {
 
     #[test]
     fn test_pipe() {
-        assert_eq!(extract_program_names("echo hello | cat"), vec!["echo", "cat"]);
+        assert_eq!(
+            extract_program_names("echo hello | cat"),
+            vec!["echo", "cat"]
+        );
     }
 
     #[test]
@@ -275,10 +277,7 @@ mod tests {
 
     #[test]
     fn test_semicolon() {
-        assert_eq!(
-            extract_program_names("echo hello; ls"),
-            vec!["echo", "ls"]
-        );
+        assert_eq!(extract_program_names("echo hello; ls"), vec!["echo", "ls"]);
     }
 
     #[test]
@@ -288,10 +287,7 @@ mod tests {
 
     #[test]
     fn test_env_var_assignment() {
-        assert_eq!(
-            extract_program_names("VAR=value echo hello"),
-            vec!["echo"]
-        );
+        assert_eq!(extract_program_names("VAR=value echo hello"), vec!["echo"]);
     }
 
     #[test]
@@ -304,19 +300,13 @@ mod tests {
 
     #[test]
     fn test_korean_env_var() {
-        assert_eq!(
-            extract_program_names("변수=all yarn lint"),
-            vec!["yarn"]
-        );
+        assert_eq!(extract_program_names("변수=all yarn lint"), vec!["yarn"]);
     }
 
     #[test]
     fn test_quoted_equals_not_assignment() {
         // '=' inside quotes should NOT be treated as assignment
-        assert_eq!(
-            extract_program_names("'VAR=value' arg"),
-            vec!["VAR=value"]
-        );
+        assert_eq!(extract_program_names("'VAR=value' arg"), vec!["VAR=value"]);
     }
 
     #[test]
@@ -332,10 +322,7 @@ mod tests {
     #[test]
     fn test_escaped_quote_in_arg() {
         // echo '변수=all a\'b' — the program is "echo"
-        assert_eq!(
-            extract_program_names("echo '변수=all a\\'b'"),
-            vec!["echo"]
-        );
+        assert_eq!(extract_program_names("echo '변수=all a\\'b'"), vec!["echo"]);
     }
 
     #[test]
@@ -366,19 +353,13 @@ mod tests {
 
     #[test]
     fn test_newline_separator() {
-        assert_eq!(
-            extract_program_names("echo hello\nls"),
-            vec!["echo", "ls"]
-        );
+        assert_eq!(extract_program_names("echo hello\nls"), vec!["echo", "ls"]);
     }
 
     #[test]
     fn test_command_substitution_with_operators() {
         // Operators inside (...) should NOT split commands
-        assert_eq!(
-            extract_program_names("echo (cmd1 && cmd2)"),
-            vec!["echo"]
-        );
+        assert_eq!(extract_program_names("echo (cmd1 && cmd2)"), vec!["echo"]);
     }
 
     #[test]
@@ -437,10 +418,7 @@ mod tests {
     fn test_complex_edge_case() {
         // The motivating edge case from the issue:
         // echo '변수=all a\'b'
-        assert_eq!(
-            extract_program_names("echo '변수=all a\\'b'"),
-            vec!["echo"]
-        );
+        assert_eq!(extract_program_names("echo '변수=all a\\'b'"), vec!["echo"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,12 @@ enum Commands {
     HasKorean {
         word: String,
     },
+    /// 한 번의 호출로 한글 감지, 명령어 위치 판별, 두벌식 변환 수행
+    Resolve {
+        token: String,
+        command_line: String,
+        cursor: usize,
+    },
     /// Fish 명령어 줄에서 프로그램 이름을 추출
     ExtractPrograms {
         command_line: String,
@@ -61,6 +67,17 @@ fn main() {
                 process::exit(1);
             }
         }
+        Commands::Resolve {
+            token,
+            command_line,
+            cursor,
+        } => {
+            if let Some(converted) = resolve_token(&token, &command_line, cursor) {
+                println!("{converted}");
+            } else {
+                process::exit(1);
+            }
+        }
         Commands::ExtractPrograms { command_line } => {
             let names = fish_parser::extract_program_names(&command_line);
             for name in names {
@@ -89,5 +106,31 @@ fn main() {
                 }
             }
         }
+    }
+}
+
+fn resolve_token(token: &str, command_line: &str, cursor: usize) -> Option<String> {
+    if !converter::contains_korean(token) || !fish_parser::is_command_position(command_line, cursor)
+    {
+        return None;
+    }
+
+    let converted = converter::convert_korean_to_english(token);
+    (converted != token).then_some(converted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_token;
+
+    #[test]
+    fn resolves_korean_command_in_one_step() {
+        assert_eq!(resolve_token("햣", "햣 status", 1).as_deref(), Some("git"));
+    }
+
+    #[test]
+    fn ignores_arguments_and_ascii_tokens() {
+        assert_eq!(resolve_token("ㅎ", "echo ㅎ", 6), None);
+        assert_eq!(resolve_token("git", "git status", 3), None);
     }
 }


### PR DESCRIPTION
## Summary

Reduce latency in the fish key-binding path while keeping command and abbreviation resolution correct on macOS.

- skip `vltl` for ASCII tokens and existing Korean abbreviations
- combine Korean detection, command-position parsing, and conversion in one `resolve` call
- cache platform detection and normalize case-insensitive macOS file commands
- remove per-conversion map and intermediate collection allocations
- enforce formatting and Clippy checks in CI

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `cargo build --release`
- `fish --no-config e2e_test.fish`
- `cargo package`
